### PR TITLE
Fix for macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,10 +129,12 @@ endif()
 # For MSVC use `_aligned_malloc`.
 ########################################################################
 include(CheckSymbolExists)
-CHECK_SYMBOL_EXISTS(aligned_alloc stdlib.h USE_ALIGNED_ALLOC)
+if(NOT (${CMAKE_SYSTEM_NAME} MATCHES "Darwin"))
+    CHECK_SYMBOL_EXISTS(aligned_alloc stdlib.h USE_ALIGNED_ALLOC)
+endif()
 if(NOT USE_ALIGNED_ALLOC)
     CHECK_SYMBOL_EXISTS(posix_memalign stdlib.h HAVE_POSIX_MEMALIGN)
-endif(USE_ALIGNED_ALLOC)
+endif()
 
 ########################################################################
 # Check if Orc is available


### PR DESCRIPTION
Although the aligned_alloc symbol is found in stdlib.h, it seems not implemented in macOS. This change makes macOS to choose the posix_memalign implementation. A runtime check would be better, but it is unlikely Apple will implement that anytime soon. This change does not affect any other OS.

Also fixes a mismatching parameter in endif()